### PR TITLE
feat: Add support for Windows builds

### DIFF
--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -1,0 +1,36 @@
+name: Build (Windows)
+
+on:
+    push:
+        branches: [ "main" ]
+    pull_request:
+        branches: [ "main" ]
+
+jobs:
+    build:
+        runs-on: windows-latest
+
+        steps:
+          - name: Checkout repository
+            uses: actions/checkout@v4
+
+          - name: Install SDL3
+            uses: libsdl-org/setup-sdl@v1
+            id: sdl
+            with:
+                version: 3-latest
+
+          - name: Install dependencies
+            run: choco install make
+
+          - name: Build for Windows
+            run: |
+                make PLATFORM=windows SDL3_PREFIX=${{ steps.sdl.outputs.prefix }} 2>&1 | tee build.log
+            shell: bash
+
+          - name: Upload build log
+            if: always()
+            uses: actions/upload-artifact@v4
+            with:
+                name: build-log
+                path: build.log

--- a/Makefile
+++ b/Makefile
@@ -188,8 +188,7 @@ else
 
 $(MAIN_TARGET): $(ALL_O_FILES) $(LIBCO_A)
 ifeq ($(PLATFORM),windows)
-	@> $(BUILD_DIR)/objects.txt
-	@for obj in $(ALL_O_FILES); do echo $$obj >> $(BUILD_DIR)/objects.txt; done
+	@find build -name '*.o' > $(BUILD_DIR)/objects.txt
 	@echo $(LIBCO_A) >> $(BUILD_DIR)/objects.txt
 	clang @$(BUILD_DIR)/objects.txt $(CLANG_LINKER_FLAGS) -o $@
 else

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ endif
 
 ifeq ($(PLATFORM),ps2)
 	MAIN := THIRD_U.BIN
+else ifeq ($(PLATFORM),windows)
+	MAIN := sf33rd.exe
 else
 	MAIN := sf33rd
 endif
@@ -92,8 +94,13 @@ CLANG_FLAGS := $(CLANG_INCLUDES) $(CLANG_WARNINGS) $(CLANG_DEFINES) -std=c99 -O0
 CLANG_LINKER_FLAGS := -lm -g -Llibco/build -llibco
 
 ifneq ($(PLATFORM),ps2)
-	CLANG_FLAGS += $(shell pkg-config --cflags sdl3)
-	CLANG_LINKER_FLAGS += $(shell pkg-config --libs sdl3)
+	ifeq ($(PLATFORM),windows)
+		CLANG_FLAGS += -I"$(SDL3_PREFIX)/include"
+		CLANG_LINKER_FLAGS += -L"$(SDL3_PREFIX)/lib" -lSDL3
+	else
+		CLANG_FLAGS += $(shell pkg-config --cflags sdl3)
+		CLANG_LINKER_FLAGS += $(shell pkg-config --libs sdl3)
+	endif
 endif
 
 # Files

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,11 @@ else
 LIBCO_A := libco/build/liblibco.a
 endif
 
-CLANG_LINKER_FLAGS := -g -Llibco/build -llibco
+ifeq ($(PLATFORM),windows)
+CLANG_LINKER_FLAGS := -g
+else
+CLANG_LINKER_FLAGS := -g -Llibco/build -llibco -lm
+endif
 
 ifneq ($(PLATFORM),ps2)
 	ifeq ($(PLATFORM),windows)
@@ -105,7 +109,7 @@ ifneq ($(PLATFORM),ps2)
 		CLANG_LINKER_FLAGS += -L"$(SDL3_PREFIX)/lib" -lSDL3
 	else
 		CLANG_FLAGS += $(shell pkg-config --cflags sdl3)
-		CLANG_LINKER_FLAGS += -lm $(shell pkg-config --libs sdl3)
+		CLANG_LINKER_FLAGS += $(shell pkg-config --libs sdl3)
 	endif
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,13 @@ $(CRI_O_FILES): $(BUILD_DIR)/%.c.o: %.c
 else
 
 $(MAIN_TARGET): $(ALL_O_FILES) libco/build/liblibco.o
-	clang $(ALL_O_FILES) $(CLANG_LINKER_FLAGS) -o $@
+ifeq ($(PLATFORM),windows)
+	@echo $(ALL_O_FILES) > $(BUILD_DIR)/objects.txt
+	@echo libco/build/liblibco.o >> $(BUILD_DIR)/objects.txt
+	clang @$(BUILD_DIR)/objects.txt $(CLANG_LINKER_FLAGS) -o $@
+else
+	clang $(ALL_O_FILES) libco/build/liblibco.o $(CLANG_LINKER_FLAGS) -o $@
+endif
 
 $(BUILD_DIR)/%.c.o: %.c
 	@mkdir -p $(dir $@)

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ else
 LIBCO_A := libco/build/liblibco.a
 endif
 
-CLANG_LINKER_FLAGS := -lm -g -Llibco/build -llibco
+CLANG_LINKER_FLAGS := -g -Llibco/build -llibco
 
 ifneq ($(PLATFORM),ps2)
 	ifeq ($(PLATFORM),windows)
@@ -105,7 +105,7 @@ ifneq ($(PLATFORM),ps2)
 		CLANG_LINKER_FLAGS += -L"$(SDL3_PREFIX)/lib" -lSDL3
 	else
 		CLANG_FLAGS += $(shell pkg-config --cflags sdl3)
-		CLANG_LINKER_FLAGS += $(shell pkg-config --libs sdl3)
+		CLANG_LINKER_FLAGS += -lm $(shell pkg-config --libs sdl3)
 	endif
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ CLANG_LINKER_FLAGS := -lm -g -Llibco/build -llibco
 
 ifneq ($(PLATFORM),ps2)
 	ifeq ($(PLATFORM),windows)
-		CLANG_FLAGS += -I"$(SDL3_PREFIX)/include"
+		CLANG_FLAGS += -I"$(SDL3_PREFIX)/include" -D_CRT_SECURE_NO_WARNINGS
 		CLANG_LINKER_FLAGS += -L"$(SDL3_PREFIX)/lib" -lSDL3
 	else
 		CLANG_FLAGS += $(shell pkg-config --cflags sdl3)

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,12 @@ CLANG_DEFINES := -DTARGET_SDL3 -DSOUND_DISABLED -DXPT_TGT_EE -D_POSIX_C_SOURCE -
 CLANG_INCLUDES := $(COMMON_INCLUDES) -Ilibco
 CLANG_FLAGS := $(CLANG_INCLUDES) $(CLANG_WARNINGS) $(CLANG_DEFINES) -std=c99 -O0
 
+ifeq ($(PLATFORM),windows)
+LIBCO_A := libco/build/Debug/libco.lib
+else
+LIBCO_A := libco/build/liblibco.a
+endif
+
 CLANG_LINKER_FLAGS := -lm -g -Llibco/build -llibco
 
 ifneq ($(PLATFORM),ps2)
@@ -180,20 +186,21 @@ $(CRI_O_FILES): $(BUILD_DIR)/%.c.o: %.c
 
 else
 
-$(MAIN_TARGET): $(ALL_O_FILES) libco/build/liblibco.o
+$(MAIN_TARGET): $(ALL_O_FILES) $(LIBCO_A)
 ifeq ($(PLATFORM),windows)
-	@echo $(ALL_O_FILES) > $(BUILD_DIR)/objects.txt
-	@echo libco/build/liblibco.o >> $(BUILD_DIR)/objects.txt
+	@> $(BUILD_DIR)/objects.txt
+	@for obj in $(ALL_O_FILES); do echo $$obj >> $(BUILD_DIR)/objects.txt; done
+	@echo $(LIBCO_A) >> $(BUILD_DIR)/objects.txt
 	clang @$(BUILD_DIR)/objects.txt $(CLANG_LINKER_FLAGS) -o $@
 else
-	clang $(ALL_O_FILES) libco/build/liblibco.o $(CLANG_LINKER_FLAGS) -o $@
+	clang $(ALL_O_FILES) $(LIBCO_A) $(CLANG_LINKER_FLAGS) -o $@
 endif
 
 $(BUILD_DIR)/%.c.o: %.c
 	@mkdir -p $(dir $@)
 	clang -g -c $< -o $@ $(CLANG_FLAGS)
 
-libco/build/liblibco.o:
+$(LIBCO_A):
 	@mkdir -p $(dir $@)
 	cd libco && \
 		mkdir -p build && \

--- a/include/types.h
+++ b/include/types.h
@@ -44,6 +44,11 @@ typedef s32 ssize_t;
 #include <stdint.h>
 #include <sys/types.h>
 
+#if defined(_WIN32) || defined(WIN32)
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#endif
+
 typedef int8_t s8;
 typedef int16_t s16;
 typedef int32_t s32;

--- a/src/anniversary/cri/libadxe/adx_fs.c
+++ b/src/anniversary/cri/libadxe/adx_fs.c
@@ -12,6 +12,8 @@
 #include <cri/sj.h>
 
 #include <memory.h>
+#include <stdio.h>
+#include <string.h>
 
 typedef struct {
     /* 0x000 */ struct _adxf_ptinfo *next;

--- a/src/anniversary/cri/libadxe/dvci_sub.c
+++ b/src/anniversary/cri/libadxe/dvci_sub.c
@@ -10,7 +10,10 @@
 
 #include <string.h>
 
-#if !defined(TARGET_PS2)
+#if defined(_WIN32)
+#include <string.h>
+#define strcasecmp _stricmp
+#elif !defined(TARGET_PS2)
 #include <strings.h>
 #endif
 

--- a/src/anniversary/port/sdk/sdk_stubs.c
+++ b/src/anniversary/port/sdk/sdk_stubs.c
@@ -18,7 +18,17 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
+
+#if defined(_WIN32)
+#include <io.h>
+#define open _open
+#define close _close
+#define read _read
+#define write _write
+#define lseek _lseek
+#else
 #include <unistd.h>
+#endif
 
 // libcdvd
 

--- a/src/anniversary/port/utils.c
+++ b/src/anniversary/port/utils.c
@@ -1,6 +1,8 @@
 #include "common.h"
 
+#if !defined(_WIN32)
 #include <execinfo.h>
+#endif
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -17,10 +19,12 @@ void fatal_error(const s8 *fmt, ...) __dead2 {
 
     va_end(args);
 
+#if !defined(_WIN32)
     void *buffer[BACKTRACE_MAX];
     int nptrs = backtrace(buffer, BACKTRACE_MAX);
     fprintf(stderr, "Stack trace:\n");
     backtrace_symbols_fd(buffer, nptrs, fileno(stderr));
+#endif
 
     abort();
 }

--- a/src/anniversary/sf33rd/AcrSDK/ps2/flps2etc.c
+++ b/src/anniversary/sf33rd/AcrSDK/ps2/flps2etc.c
@@ -21,7 +21,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#if !defined(TARGET_PS2)
+#if !defined(TARGET_PS2) && !defined(_WIN32)
 #include <ctype.h>
 
 s8 *strupr(s8 *s) {
@@ -75,7 +75,11 @@ s32 flFileRead(s8 *filename, void *buf, s32 len) {
     strcpy(temp, "cdrom0:\\THIRD\\");
     p = strlen(temp) + temp;
     strcat(temp, filename);
+#ifdef _WIN32
+    _strupr(p);
+#else
     strupr(p);
+#endif
     strcat(temp, ";1");
 
     ADXM_Lock();
@@ -101,7 +105,11 @@ s32 flFileWrite(s8 *filename, void *buf, s32 len) {
     strcpy(temp, "cdrom0:\\THIRD\\");
     p = strlen(temp) + temp;
     strcat(temp, filename);
+#ifdef _WIN32
+    _strupr(p);
+#else
     strupr(p);
+#endif
     strcat(temp, ";1");
     ADXM_Lock();
 
@@ -124,7 +132,11 @@ s32 flFileAppend(s8 *filename, void *buf, ssize_t len) {
     strcpy(temp, "cdrom0:\\THIRD\\");
     p = strlen(temp) + temp;
     strcat(temp, filename);
+#ifdef _WIN32
+    _strupr(p);
+#else
     strupr(p);
+#endif
     strcat(temp, ";1");
     ADXM_Lock();
 
@@ -149,7 +161,11 @@ s32 flFileLength(s8 *filename) {
     strcpy(temp, "cdrom0:\\THIRD\\");
     p = strlen(temp) + temp;
     strcat(temp, filename);
+#ifdef _WIN32
+    _strupr(p);
+#else
     strupr(p);
+#endif
     strcat(temp, ";1");
     ADXM_Lock();
 


### PR DESCRIPTION
This commit introduces the necessary changes to enable building the project for the Windows platform.

A new GitHub Actions workflow, `build_windows.yml`, has been added to automate the build process on a Windows runner. This workflow handles the installation of dependencies, including SDL3, and executes the build.

The `Makefile` has been updated to support the 'windows' platform. This includes:
- Setting the correct executable name with a '.exe' extension.
- Adding platform-specific compiler and linker flags for Windows.
- Using the `SDL3_PREFIX` environment variable to locate the SDL3 library, making it suitable for CI environments.